### PR TITLE
1.0.9 Changes #2

### DIFF
--- a/Void.INC/Initialisation/Re-initialisation.hpp
+++ b/Void.INC/Initialisation/Re-initialisation.hpp
@@ -29,7 +29,7 @@ inline void drawConfirmPopup(sf::RenderWindow& window, bool& startInit, sf::Vect
     sf::Vector2f mousePos = window.mapPixelToCoords(sf::Mouse::getPosition(window));
     sf::Vector2f boxSize(550.f, 220.f);
 
-    sf::RectangleShape overlay({ (float)window.getSize().x, (float)window.getSize().y });
+    sf::RectangleShape overlay(sf::Vector2f(window.getSize()));
     overlay.setFillColor(sf::Color(0, 0, 0, 180));
     window.draw(overlay);
 

--- a/Void.INC/Misc/Globals/GFunctions.hpp
+++ b/Void.INC/Misc/Globals/GFunctions.hpp
@@ -15,3 +15,8 @@ inline void centreText(sf::Text& text, sf::Vector2f targetPos) {
     text.setOrigin({ textRect.position.x + textRect.size.x / 2.0f, textRect.position.y + textRect.size.y / 2.0f });
     text.setPosition(targetPos);
 }
+
+template<typename T>
+T lerp(T a, T b, T t) {
+    return a + t * (b - a);
+}

--- a/Void.INC/Misc/Globals/GIncludes.hpp
+++ b/Void.INC/Misc/Globals/GIncludes.hpp
@@ -24,7 +24,6 @@
 #include <vector>
 #include <Windows.h>
 
-#include "../ini.h"
 #include "../json.hpp"
 
 using json = nlohmann::json;

--- a/Void.INC/Misc/Globals/GVariables.hpp
+++ b/Void.INC/Misc/Globals/GVariables.hpp
@@ -42,11 +42,19 @@ enum class StartState {
 };
 inline StartState currentStartStep = StartState::IDLE;
 
+// Click states
 inline bool canClickStart = true; // Start menu only
 inline bool canClick = false; // Pre-reinitialisation
 inline bool canClickInit = false; // Post-initialisation
+inline bool canClickOptions = false; // Options menu only
 
-enum class Tab { NONE, LOGIC, HOTFIX, REINIT };
+enum class Tab {
+    NONE,
+    LOGIC,
+    HOTFIX,
+    REINIT,
+    STATS
+};
 inline Tab activeTab = Tab::NONE;
 inline float tabProgress = 0.f;
 
@@ -87,6 +95,13 @@ inline float patch_3_2Mult = 1.0L; // Multiplier from Patch_3_2
 inline float patch_7_2Mult = 1.0L; // Multiplier from Patch_7_2
 inline bool showConfirmPopup = false;
 
+inline long double malbits = 0.0L; // Malicious bits (for 1.1 use)
 inline long double malbytes = 0.0L; // Malicious bytes (for 1.1 use)
 
-inline sf::Font jetBrainsMono("Assets/Font/JetBrainsMono.ttf");
+inline sf::Font jetBrainsMono("Assets/Font/JetBrainsMono.ttf"); // Main font (kind of obvious)
+
+// Options variables
+inline bool showOptions = false; // Toggles the options menu
+
+inline bool renderEffects = true; // Toggles rendering effects in the Void.INC/Effects folder
+inline bool quickStart = false; // Toggles the start menu

--- a/Void.INC/UI/Core/Terminal.hpp
+++ b/Void.INC/UI/Core/Terminal.hpp
@@ -273,7 +273,7 @@ inline void drawTerminalUI(sf::RenderWindow& window, long double& bits, long dou
                 bTxt.setFillColor(sf::Color(243, 238, 225));
                 window.draw(bTxt);
 
-                if (bHover && sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && cooldown.getElapsedTime().asMilliseconds() > 300) {
+                if (bHover && sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && cooldown.getElapsedTime().asMilliseconds() > 200) {
                     for (auto& hf : hotfixList) {
                         if (!hf.written && bits >= hf.bits) {
                             bits -= hf.bits;

--- a/Void.INC/UI/Extra/Offline.hpp
+++ b/Void.INC/UI/Extra/Offline.hpp
@@ -7,7 +7,7 @@ inline void drawOfflineUI(sf::RenderWindow& window, sf::Vector2f& centre) {
 	sf::Vector2f mousePos = window.mapPixelToCoords(sf::Mouse::getPosition(window));
 	sf::Vector2f boxSize(550.f, 200.f);
 
-	sf::RectangleShape overlay({ (float)window.getSize().x, (float)window.getSize().y });
+	sf::RectangleShape overlay(sf::Vector2f(window.getSize()));
 	overlay.setFillColor(sf::Color(0, 0, 0, 180));
 	window.draw(overlay);
 

--- a/Void.INC/UI/Extra/Options.hpp
+++ b/Void.INC/UI/Extra/Options.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+#include "../../Misc/Globals/GIncludes.hpp"
+#include "../../Misc/Globals/GFunctions.hpp"
+#include "../../Misc/Globals/GVariables.hpp"
+
+struct Cog {
+    sf::VertexArray cog;
+    float rotation = 0.f;
+    float currentRotationSpeed = 0.f;
+    sf::FloatRect bounds;
+
+    Cog() {
+        cog.setPrimitiveType(sf::PrimitiveType::TriangleFan);
+    }
+};
+
+inline void updateCog(Cog& cog, sf::RenderWindow& window, float dt, bool& showOptions) {
+    const int segments = 16;
+    const float outerRadius = 25.f;
+    const float innerRadius = 18.f;
+    const float margin = 40.f;
+
+    sf::Vector2f winSize = sf::Vector2f(window.getSize());
+    sf::Vector2f topRightPos = { winSize.x - margin, margin };
+
+    sf::Vector2f mousePos = window.mapPixelToCoords(sf::Mouse::getPosition(window));
+
+    cog.bounds = sf::FloatRect({ topRightPos.x - outerRadius, topRightPos.y - outerRadius },
+        { outerRadius * 2.f, outerRadius * 2.f });
+
+    bool cHover = cog.bounds.contains(mousePos);
+
+    float targetSpeed = (cHover || showOptions) ? 150.f : 0.f;
+    cog.currentRotationSpeed = lerp(cog.currentRotationSpeed, targetSpeed, std::clamp(dt * 4.f, 0.f, 1.f));
+    cog.rotation += cog.currentRotationSpeed * dt;
+
+    cog.cog.setPrimitiveType(sf::PrimitiveType::TriangleFan);
+    cog.cog.clear();
+
+    cog.cog.append(sf::Vertex{ topRightPos, sf::Color::Black });
+
+    for (int i = 0; i <= segments; ++i) {
+        float angle = (i * 2.f * pi / segments) + (cog.rotation * pi / 180.f);
+        float r = (i % 2 == 0) ? outerRadius : innerRadius;
+
+        sf::Vector2f vertexPos = topRightPos + sf::Vector2f(std::cos(angle) * r, std::sin(angle) * r);
+
+        sf::Color colour = cHover ? sf::Color(100, 100, 100) : sf::Color(40, 40, 40);
+
+        cog.cog.append(sf::Vertex{ vertexPos, colour });
+    }
+
+    if ((cHover && sf::Mouse::isButtonPressed(sf::Mouse::Button::Left)) && cooldown.getElapsedTime().asMilliseconds() > 200) {
+        showOptions = true;
+        canClickOptions = true;
+        cooldown.restart();
+
+		if (showStart) canClickStart = false;
+        if (!showStart) canClick = false;
+        if (reinitialisation) canClickInit = false;
+    }
+}
+
+struct ConfigOption {
+    std::string option;
+    bool* toggle;
+};
+
+inline void drawOptionsUI(sf::RenderWindow& window, bool& showOptions, sf::Vector2f& centre) {
+    sf::Vector2f mousePos = window.mapPixelToCoords(sf::Mouse::getPosition(window));
+
+    static std::vector<ConfigOption> options = {
+        {"RENDER_EFFECTS", &renderEffects},
+        {"QUICK_START", &quickStart}
+    };
+
+    float linePadding = 30.f;
+    sf::Vector2f boxSize(550.f, 60.f + (options.size() * linePadding));
+
+    sf::RectangleShape overlay(sf::Vector2f(window.getSize()));
+    overlay.setFillColor(sf::Color(0, 0, 0, 180));
+    window.draw(overlay);
+
+    sf::RectangleShape box(boxSize);
+    box.setOrigin(boxSize / 2.f);
+    box.setPosition(centre);
+    box.setFillColor(sf::Color(10, 10, 10));
+    box.setOutlineColor(sf::Color(50, 50, 50));
+    box.setOutlineThickness(1);
+
+    sf::RectangleShape titleBar({ boxSize.x, 30.f });
+    titleBar.setOrigin({ boxSize.x / 2.f, 0.f });
+    titleBar.setPosition({ centre.x, centre.y - (boxSize.y / 2.f) });
+    titleBar.setFillColor(sf::Color(40, 40, 40));
+
+    sf::Text t(jetBrainsMono, "> void://hardware/options.ini" + getCursor(), 14);
+    t.setPosition({ titleBar.getPosition().x - (boxSize.x / 2.f) + 10.f, titleBar.getPosition().y + 5.f });
+    t.setFillColor(sf::Color(243, 238, 225));
+
+    sf::Text c(jetBrainsMono, "- X", 14);
+    c.setPosition({ titleBar.getPosition().x + ((boxSize.x / 2.f) * 0.85f), titleBar.getPosition().y + 5.f });
+    c.setFillColor(sf::Color(243, 238, 225));
+
+    window.draw(box);
+    window.draw(titleBar);
+    window.draw(t);
+    window.draw(c);
+
+    float startY = titleBar.getPosition().y + 45.f;
+    for (size_t i = 0; i < options.size(); ++i) {
+        sf::Vector2f linePos = { titleBar.getPosition().x - (boxSize.x / 2.f) + 20.f, startY + (i * linePadding) };
+
+        sf::Text optText(jetBrainsMono, options[i].option + ".sys", 13);
+        optText.setPosition(linePos);
+
+        bool isHovered = optText.getGlobalBounds().contains(mousePos);
+        bool isActive = *options[i].toggle;
+
+        if (isHovered) {
+            optText.setFillColor(sf::Color(243, 238, 225));
+        }
+        else {
+            optText.setFillColor(isActive ? sf::Color(140, 140, 140) : sf::Color(80, 80, 80));
+        }
+
+        if (isHovered && sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && canClickOptions && cooldown.getElapsedTime().asMilliseconds() > 200) {
+            *options[i].toggle = !(*options[i].toggle);
+            cooldown.restart();
+        }
+
+        window.draw(optText);
+
+        sf::Text indicator(jetBrainsMono, isActive ? "[x]" : "[ ]", 13);
+        indicator.setPosition({ titleBar.getPosition().x + (boxSize.x / 2.f) - 60.f, linePos.y });
+        indicator.setFillColor(optText.getFillColor());
+        window.draw(indicator);
+    }
+
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Escape) || sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && c.getGlobalBounds().contains(mousePos)) {
+        showOptions = false;
+        canClickOptions = false;
+
+        if (showStart) canClickStart = true;
+        if (!showStart) canClick = true;
+        if (reinitialisation) canClickInit = true;
+    }
+}

--- a/Void.INC/UI/Extra/Settings.hpp
+++ b/Void.INC/UI/Extra/Settings.hpp
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "../../Misc/Globals/GIncludes.hpp"
-#include "../../Misc/Globals/GVariables.hpp"
-
-inline void drawCog(sf::RenderWindow& window) {
-
-}

--- a/Void.INC/UI/Extra/Start.hpp
+++ b/Void.INC/UI/Extra/Start.hpp
@@ -2,8 +2,8 @@
 
 #include "../../Misc/Globals/GIncludes.hpp"
 
-inline void drawStartUI(sf::RenderWindow& window, sf::RenderStates& states, Star& star, float et, float dt, sf::Vector2f& pos) {
-	const sf::Vector2f mousePos = window.mapPixelToCoords(sf::Mouse::getPosition(window));
+inline void drawStartUI(sf::RenderWindow& window, sf::RenderStates& states, Star& star, float et, float dt, sf::Vector2f& sPos, sf::Vector2f& centre) {
+	sf::Vector2f mousePos = window.mapPixelToCoords(sf::Mouse::getPosition(window));
 
 	sf::Text t(jetBrainsMono, "Void.INC", 124);
 	t.setPosition({ 80, window.getSize().y * 0.05f });
@@ -18,34 +18,44 @@ inline void drawStartUI(sf::RenderWindow& window, sf::RenderStates& states, Star
 	bool pHover = e.getGlobalBounds().contains(mousePos);
 	e.setFillColor(pHover ? sf::Color(200, 200, 30) : sf::Color(243, 238, 225));
 
-	sf::Text s(jetBrainsMono, "Options", 48);
-	s.setPosition({ 80, window.getSize().y * 0.6f });
-	s.setFillColor(sf::Color(140, 140, 140));
+	sf::Text o(jetBrainsMono, "Options", 48);
+	o.setPosition({ 80, window.getSize().y * 0.6f });
+	bool oHover = o.getGlobalBounds().contains(mousePos);
+	o.setFillColor(oHover ? sf::Color(200, 200, 30) : sf::Color(243, 238, 225));
 
 	sf::Text q(jetBrainsMono, "Quit", 48);
 	q.setPosition({ 80, window.getSize().y * 0.7f });
 	bool qHover = q.getGlobalBounds().contains(mousePos);
 	q.setFillColor(qHover ? sf::Color(200, 200, 30) : sf::Color(243, 238, 225));
 
-	updateStar(star, pos, et, 1.f, allBits);
-	updateStream(window, pos, dt, 2);
+	updateStar(star, sPos, et, 1.f, allBits);
 	window.draw(star.star, states);
-	for (auto& d : dataStream) {
-		window.draw(d.bit);
+	
+	if (renderEffects) {
+		updateStream(window, sPos, dt, 2);
+		for (auto& d : dataStream) {
+			window.draw(d.bit);
+		}
 	}
 
 	if (!start) {
 		window.draw(t);
 		window.draw(v);
 		window.draw(e);
-		window.draw(s);
+		window.draw(o);
 		window.draw(q);
 	}
 
-	if (sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && cooldown.getElapsedTime().asMilliseconds() > 300) {
+	if (sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && cooldown.getElapsedTime().asMilliseconds() > 200) {
 		if (pHover && canClickStart) {
 			start = true;
 		}
+		if (oHover && canClickStart) {
+			showOptions = true;
+			canClickStart = false;
+			canClickOptions = true;
+		}
+		if (showOptions) drawOptionsUI(window, showOptions, centre);
 		if (qHover && canClickStart) {
 			window.close();
 		}

--- a/Void.INC/UserData/Local/Options.hpp
+++ b/Void.INC/UserData/Local/Options.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "../../Misc/Globals/GIncludes.hpp"
+
+inline void saveSettings(
+	bool renderEffects,
+	bool quickStart
+) {
+	std::ofstream file("options.txt");
+
+	if (file.is_open()) {
+		file << (renderEffects ? "1" : "0") << std::endl;
+		file << (quickStart ? "1" : "0") << std::endl;
+		file.close();
+	}
+	if (!file.is_open()) std::cerr << "Unable to open options.txt." << std::endl;
+}
+
+inline void loadSettings(
+	bool& renderEffects,
+	bool& quickStart
+) {
+	std::ifstream file("options.txt");
+	if (!file.is_open()) {
+		std::cerr << "No options file found." << std::endl;
+		renderEffects = true;
+		quickStart = false;
+		return;
+	}
+
+	std::string line;
+	std::getline(file, line);
+	renderEffects = (line == "1");
+	std::getline(file, line);
+	quickStart = (line == "1");
+	file.close();
+}

--- a/Void.INC/UserData/Local/Settings.hpp
+++ b/Void.INC/UserData/Local/Settings.hpp
@@ -1,3 +1,0 @@
-#pragma once
-
-#include "../../Misc/Globals/GIncludes.hpp"

--- a/Void.INC/Void_INC.cpp
+++ b/Void.INC/Void_INC.cpp
@@ -18,11 +18,12 @@
 #include "UI/Core/Terminal.hpp"
 #include "UI/Extra/Loading.hpp"
 #include "UI/Extra/Offline.hpp"
-#include "UI/Extra/Settings.hpp"
+#include "UI/Extra/Options.hpp"
 #include "UI/Extra/Star.hpp"
 #include "UI/Extra/Start.hpp"
 
 #include "UserData/Local/Loading.hpp"
+#include "UserData/Local/Options.hpp"
 #include "UserData/Local/Saving.hpp"
 #include "UserData/Local/Version.hpp"
 
@@ -53,6 +54,8 @@ int main() {
 	star.star = sf::VertexArray(sf::PrimitiveType::LineStrip, 4000);
 	float starScale = 1.f;
 
+	Cog cog;
+
 	sf::VertexArray lines(sf::PrimitiveType::Lines);
 	for (int i = 0; i < window.getSize().y; i += 4) {
 		lines.append(sf::Vertex{ sf::Vector2f(0.f, (float)i), sf::Color(255, 255, 255, 40) });
@@ -76,6 +79,7 @@ int main() {
 	initDirTree();
 	positionTreeNodes(window.getSize());
 	load(timeEnd, bits, bytes, allBits, allClickedBits, bitsPerSecond, hotfixMult, timesInitialised, logicGateList, hotfixList, dirTree);
+	loadSettings(renderEffects, quickStart);
 	offline(timeEnd, bits, allBits, bitsPerSecond, hotfixMult);
 	
 	while (window.isOpen()) {
@@ -202,11 +206,11 @@ int main() {
 
 		window.clear(sf::Color::Black);
 
-		if (showStart) {
-			drawStartUI(window, states, star, elapsedTime, deltaTime, sPos);
+		if (showStart && !quickStart) {
+			drawStartUI(window, states, star, elapsedTime, deltaTime, sPos, centre);
 		}
 
-		if (start) {
+		if (start && !quickStart) {
 			if (currentStartStep == StartState::IDLE) currentStartStep = StartState::TRANSITION;
 			timer += deltaTime;
 			canClickStart = false;
@@ -231,14 +235,21 @@ int main() {
 			}
 		}
 
-		if (!showStart) {
+		if (!showStart || quickStart) {
+			if (quickStart) {
+				showStart = false;
+				canClick = true;
+				if (!rolledWhisper) showOffline = true;
+			}
 			if (!reinitialisation && !initialisation) {
 				window.draw(bitsText);
 				window.draw(bitsPerSecondText);
 
-				updateStream(window, centre, deltaTime, 2);
-				for (auto& d : dataStream) {
-					window.draw(d.bit);
+				if (renderEffects) {
+					updateStream(window, centre, deltaTime, 2);
+					for (auto& d : dataStream) {
+						window.draw(d.bit);
+					}
 				}
 
 				updateLogicGateUI(window, allBits);
@@ -307,9 +318,11 @@ int main() {
 				timer = 0.0f;
 				canClickInit = true;
 
-				updateStream(window, centre, deltaTime, 1);
-				for (auto& d : dataStream) {
-					window.draw(d.bit);
+				if (renderEffects) {
+					updateStream(window, centre, deltaTime, 1);
+					for (auto& d : dataStream) {
+						window.draw(d.bit);
+					}
 				}
 
 				drawTreeLines(window);
@@ -368,6 +381,12 @@ int main() {
 			}
 			}
 		}
+		
+		if (!showStart) {
+			updateCog(cog, window, deltaTime, showOptions);
+			window.draw(cog.cog);
+		}
+		if (showOptions) drawOptionsUI(window, showOptions, centre);
 
 		window.draw(lines);
 
@@ -377,6 +396,7 @@ int main() {
 			if (gameEvent->is<sf::Event::Closed>()) {
 				time_t timeStart = time(nullptr);
 				save(timeStart, bits, bytes, allBits, allClickedBits, bitsPerSecond, hotfixMult, timesInitialised, logicGateList, hotfixList, dirTree);
+				saveSettings(renderEffects, quickStart);
 				versionSave(voidVersion);
 				window.close();
 			}


### PR DESCRIPTION
Added limited options for 1.0.9
- RENDER_EFFECTS: toggles effects listed in the `Void.INC/Effects` folder (only applicable to `../Bits.hpp` currently
- QUICK_START: skips the start menu entirely if that's, for some reason, inconvenient